### PR TITLE
APNG Support/2.6.0

### DIFF
--- a/Attorney_Online_remake.pro
+++ b/Attorney_Online_remake.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui multimedia network
-
+QTPLUGIN += qapng
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 RC_ICONS = logo.ico
@@ -88,7 +88,7 @@ HEADERS  += lobby.h \
 #    in the same way as BASS. Discord RPC uses CMake, which does not play nicely with
 #    QMake, so this step must be manual.
 unix:LIBS += -L$$PWD -lbass -ldiscord-rpc
-win32:LIBS += -L$$PWD "$$PWD/bass.dll" -L$$PWD "$$PWD/discord-rpc.dll"
+win32:LIBS += -L$$PWD "$$PWD/bass.dll" -L$$PWD "$$PWD/discord-rpc.dll" -lpng -lqapng -lz
 android:LIBS += -L$$PWD\android\libs\armeabi-v7a\ -lbass
 
 CONFIG += c++11

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -231,8 +231,8 @@ public:
 
 private:
   const int RELEASE = 2;
-  const int MAJOR_VERSION = 5;
-  const int MINOR_VERSION = 2;
+  const int MAJOR_VERSION = 6;
+  const int MINOR_VERSION = 0;
 
   QString current_theme = "default";
 

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -172,6 +172,9 @@ public:
   //Figure out if we can opus this or if we should fall back to wav
   QString get_sfx_suffix(QString sound_to_check);
 
+  // Can we use APNG for this? If not, fall back to a gif.
+  QString get_image_suffix(QString path_to_check);
+
   //Returns the value of p_search_line within target_tag and terminator_tag
   QString read_char_ini(QString p_char, QString p_search_line, QString target_tag, QString terminator_tag);
 

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -3,6 +3,8 @@
 #include "misc_functions.h"
 #include "file_functions.h"
 #include "aoapplication.h"
+#include "debug_functions.h"
+#include <string>
 
 AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
 {
@@ -21,11 +23,14 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 {
   QString original_path = ao_app->get_character_path(p_char) + emote_prefix + p_emote.toLower() + ".gif";
   QString alt_path = ao_app->get_character_path(p_char) + p_emote.toLower() + ".png";
+  QString apng_path = ao_app->get_character_path(p_char) + emote_prefix + p_emote.toLower() + ".apng";
   QString placeholder_path = ao_app->get_theme_path() + "placeholder.gif";
   QString placeholder_default_path = ao_app->get_default_theme_path() + "placeholder.gif";
   QString gif_path;
 
-  if (file_exists(original_path))
+  if (file_exists(apng_path))
+    gif_path = apng_path;
+  else if (file_exists(original_path))
     gif_path = original_path;
   else if (file_exists(alt_path))
     gif_path = alt_path;
@@ -148,6 +153,7 @@ void AOCharMovie::combo_resize(int w, int h)
 
 void AOCharMovie::frame_change(int n_frame)
 {
+
   if (movie_frames.size() > n_frame)
   {
     QPixmap f_pixmap = QPixmap::fromImage(movie_frames.at(n_frame));

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -3,8 +3,6 @@
 #include "misc_functions.h"
 #include "file_functions.h"
 #include "aoapplication.h"
-#include "debug_functions.h"
-#include <string>
 
 AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
 {

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -28,9 +28,9 @@ void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme)
 
   QString custom_path;
   if (p_gif == "custom")
-    custom_path = ao_app->get_character_path(p_char) + p_gif + ".gif";
+    custom_path = ao_app->get_image_suffix(ao_app->get_character_path(p_char) + p_gif);
   else
-    custom_path = ao_app->get_character_path(p_char) + p_gif + "_bubble.gif";
+    custom_path = ao_app->get_image_suffix(ao_app->get_character_path(p_char) + p_gif + "_bubble");
 
   QString custom_theme_path = ao_app->get_base_path() + "themes/" + p_custom_theme + "/" + p_gif + ".gif";
   QString theme_path = ao_app->get_theme_path() + p_gif + ".gif";

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -703,7 +703,7 @@ void Courtroom::enter_courtroom(int p_cid)
   QString char_path = ao_app->get_character_path(current_char);
 
   if (ao_app->custom_objection_enabled &&
-      file_exists(char_path + "custom.gif") &&
+      (file_exists(char_path + "custom.gif") || file_exists(char_path + "custom.apng")) &&
       file_exists(char_path + "custom.wav"))
     ui_custom_objection->show();
   else

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1219,13 +1219,13 @@ void Courtroom::play_preanim()
     preanim_duration = ao2_duration;
 
   sfx_delay_timer->start(sfx_delay);
-
-  if (!file_exists(ao_app->get_character_path(f_char) + f_preanim.toLower() + ".gif") ||
+  QString anim_to_find = ao_app->get_image_suffix(ao_app->get_character_path(f_char) + f_preanim.toLower());
+  if (!file_exists(anim_to_find) ||
       preanim_duration < 0)
   {
     anim_state = 1;
     preanim_done();
-    qDebug() << "could not find " + ao_app->get_character_path(f_char) + f_preanim.toLower() + ".gif";
+    qDebug() << "could not find " + anim_to_find;
     return;
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,9 +5,9 @@
 #include "networkmanager.h"
 #include "lobby.h"
 #include "courtroom.h"
-
+#include <QPluginLoader>
 #include <QDebug>
-
+Q_IMPORT_PLUGIN(ApngImagePlugin);
 int main(int argc, char *argv[])
 {
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
@@ -16,10 +16,10 @@ int main(int argc, char *argv[])
     // packages up to Qt 5.6, so this is conditional.
     AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
+
     AOApplication main_app(argc, argv);
     main_app.construct_lobby();
     main_app.net_manager->connect_to_master();
     main_app.w_lobby->show();
-
     return main_app.exec();
 }

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -342,7 +342,6 @@ QString AOApplication::get_sfx(QString p_identifier)
 
 QString AOApplication::get_sfx_suffix(QString sound_to_check)
 {
-    QString wav_check = get_sounds_path() + sound_to_check + ".wav";
     QString mp3_check = get_sounds_path() + sound_to_check + ".mp3";
     QString opus_check = get_sounds_path() + sound_to_check + ".opus";
     if(file_exists(opus_check))
@@ -353,24 +352,15 @@ QString AOApplication::get_sfx_suffix(QString sound_to_check)
     {
         return sound_to_check + ".mp3";
     }
-    if(file_exists(wav_check))
-    {
-        return sound_to_check + ".wav";
-    }
     return sound_to_check + ".wav";
 }
 
 QString AOApplication::get_image_suffix(QString path_to_check)
 {
     QString apng_check = path_to_check + ".apng";
-    QString gif_check = path_to_check + ".gif";
     if(file_exists(apng_check))
     {
         return path_to_check + ".apng";
-    }
-    if(file_exists(gif_check))
-    {
-        return path_to_check + ".gif";
     }
     return path_to_check + ".gif";
 }

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -360,6 +360,22 @@ QString AOApplication::get_sfx_suffix(QString sound_to_check)
     return sound_to_check + ".wav";
 }
 
+QString AOApplication::get_image_suffix(QString path_to_check)
+{
+    QString apng_check = path_to_check + ".apng";
+    QString gif_check = path_to_check + ".gif";
+    if(file_exists(apng_check))
+    {
+        return path_to_check + ".apng";
+    }
+    if(file_exists(gif_check))
+    {
+        return path_to_check + ".gif";
+    }
+    return path_to_check + ".gif";
+}
+
+
 //returns whatever is to the right of "search_line =" within target_tag and terminator_tag, trimmed
 //returns the empty string if the search line couldnt be found
 QString AOApplication::read_char_ini(QString p_char, QString p_search_line, QString target_tag, QString terminator_tag)


### PR DESCRIPTION
**Takes advantage of QtApng to save everyone time and headache of rolling our own apng solution.**
https://github.com/Skycoder42/QtApng

You'll want to recompile it as a static plugin and do all the needed crap to get that to work along with the patched deps it uses with your setup, your choice as long as it compiles t b h

Beta compile of this in the mods channel and handed out to apng people so they can get cool shots of it working in game with new content to show why it's the superior format or something

Thanks to the Danganronpa Online dev(s) and Longbyte for assisting in getting the actual qt side of things working.